### PR TITLE
(fix): Symlinks no longer break backup sequence

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "scripts": {
-    "start": "NODE_ENV=dev tsc && node dist/app.js restore --ref 1bf4d842-f7d8-400a-8b0c-1cbdb28ba50e --dest ./dev/restore",
+    "start": "NODE_ENV=dev tsc && node dist/app.js backup --name test-ref --source ~/Documents/Personal --dest ./dev",
     "build": "NODE_ENV=production tsc",
     "lint": "NODE_ENV=test eslint \"{src,libs,test}/**/*.ts\" --fix",
     "test": "echo \"WARN: no test specified\" && exit 0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "scripts": {
-    "start": "NODE_ENV=dev tsc && node dist/app.js restore --ref 6cefdfe8-6957-45af-9ebf-5516876d17ba --dest ./dev/restore",
+    "start": "NODE_ENV=dev tsc && node dist/app.js restore --ref 1bf4d842-f7d8-400a-8b0c-1cbdb28ba50e --dest ./dev/restore",
     "build": "NODE_ENV=production tsc",
     "lint": "NODE_ENV=test eslint \"{src,libs,test}/**/*.ts\" --fix",
     "test": "echo \"WARN: no test specified\" && exit 0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "scripts": {
-    "start": "NODE_ENV=dev tsc && node dist/app.js config --help",
+    "start": "NODE_ENV=dev tsc && node dist/app.js backup --name symlink-test --source /usr/local/bin --dest ./dev",
     "build": "NODE_ENV=production tsc",
     "lint": "NODE_ENV=test eslint \"{src,libs,test}/**/*.ts\" --fix",
     "test": "echo \"WARN: no test specified\" && exit 0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "scripts": {
-    "start": "NODE_ENV=dev tsc && node dist/app.js backup --name symlink-test-var --source /var --dest ~/",
+    "start": "NODE_ENV=dev tsc && node dist/app.js backup --name symlink-test-var --source /usr/local --dest ./dev",
     "build": "NODE_ENV=production tsc",
     "lint": "NODE_ENV=test eslint \"{src,libs,test}/**/*.ts\" --fix",
     "test": "echo \"WARN: no test specified\" && exit 0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backuply",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A simple backup client for automating schedule file backups safely",
   "exports": "./dist/app.js",
   "types": "./dist/app.d.ts",
@@ -9,7 +9,7 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "scripts": {
-    "start": "NODE_ENV=dev tsc && node dist/app.js backup --name symlink-test-var --source /usr/local --dest ./dev",
+    "start": "NODE_ENV=dev tsc && node dist/app.js restore --ref 9b24d3df-a1d9-4489-9f88-5281de8a7eba --dest ./dev",
     "build": "NODE_ENV=production tsc",
     "lint": "NODE_ENV=test eslint \"{src,libs,test}/**/*.ts\" --fix",
     "test": "echo \"WARN: no test specified\" && exit 0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "scripts": {
-    "start": "NODE_ENV=dev tsc && node dist/app.js backup --name symlink-test --source /usr/local/bin --dest ./dev",
+    "start": "NODE_ENV=dev tsc && node dist/app.js backup --name symlink-test-var --source /var --dest ~/",
     "build": "NODE_ENV=production tsc",
     "lint": "NODE_ENV=test eslint \"{src,libs,test}/**/*.ts\" --fix",
     "test": "echo \"WARN: no test specified\" && exit 0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "scripts": {
-    "start": "NODE_ENV=dev tsc && node dist/app.js restore --ref 9b24d3df-a1d9-4489-9f88-5281de8a7eba --dest ./dev",
+    "start": "NODE_ENV=dev tsc && node dist/app.js restore --ref 6cefdfe8-6957-45af-9ebf-5516876d17ba --dest ./dev/restore",
     "build": "NODE_ENV=production tsc",
     "lint": "NODE_ENV=test eslint \"{src,libs,test}/**/*.ts\" --fix",
     "test": "echo \"WARN: no test specified\" && exit 0"

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,13 +1,13 @@
 #! /usr/bin/env node
 
 // Entrypoint to application
-import { makeBackup } from './common/commands/backup.js';
-import { parseArgs } from './common/commands/parsing.js';
-import { restoreBackup } from './common/commands/restore.js';
-import { ppRecord, sayHello } from './common/functions.js';
-import { AppConfig } from './lib/configuration.js';
-import { DatabaseManager } from './lib/database.js';
-import { log } from "./lib/logger.js";
+import { makeBackup } from './common/commands/backup.js'
+import { parseArgs } from './common/commands/parsing.js'
+import { restoreBackup } from './common/commands/restore.js'
+import { ppRecord, sayHello } from './common/functions.js'
+import { AppConfig } from './lib/configuration.js'
+import { DatabaseManager } from './lib/database.js'
+import { log } from './lib/logger.js'
 
 // Define commandline options
 const cmdArgs = parseArgs()
@@ -49,7 +49,7 @@ const run = async () => {
 
 			log(`Backup successfully created. See details below:\n`)
 			ppRecord(res) // Print the created record in a pretty way :p
-			break;
+			break
 		}
 		case 'restore': {
 			const [ res, err ] = await restoreBackup(cmdArgs['ref'], cmdArgs['dest'])
@@ -60,7 +60,7 @@ const run = async () => {
 			}
 
 			log(`Backup with ID, ${res}, successfully restored to ${cmdArgs['dest']}`)
-			break;
+			break
 		}
 		default: {
 			log(`WARN: Invalid command specified`)

--- a/src/common/commands/backup.ts
+++ b/src/common/commands/backup.ts
@@ -1,63 +1,73 @@
-import ora from "ora"
-import { resolve } from "path/posix"
-import { cwd } from "process"
-import { BackupManager } from "../../lib/backup.js"
-import { log } from "../../lib/logger.js"
-import { BackupRecord } from "../types.js"
+import ora from 'ora'
+import { resolve } from 'path/posix'
+import { cwd } from 'process'
+import { BackupManager } from '../../lib/backup.js'
+import { log } from '../../lib/logger.js'
+import { BackupRecord } from '../types.js'
 
-export async function makeBackup(name: string, src: string, dest: string, ref?: string): Promise<[ BackupRecord, Error ]> {
-  try {
-    // Validate input
-    if (!name || name.length === 0 || !dest || dest.length === 0) {
-      return [ null, new Error(`Invalid options specified...`) ]
-    }
-    log(`Parameters validated ... deciding which backup method to use ...`)
+export async function makeBackup(
+	name: string,
+	src: string,
+	dest: string,
+	ref?: string
+): Promise<[BackupRecord, Error]> {
+	try {
+		// Validate input
+		if (!name || name.length === 0 || !dest || dest.length === 0) {
+			return [ null, new Error(`Invalid options specified...`) ]
+		}
+		log(`Parameters validated ... deciding which backup method to use ...`)
 
-    // Differential backup
-    if (ref && ref.length > 0) return await differentialBackup(name, src, dest, ref)
+		// Differential backup
+		if (ref && ref.length > 0) return await differentialBackup(name, src, dest, ref)
 
-    // Full backup
-    if (src && src.length > 0) return await fullBackup(name, src, dest)
-  } catch (err) {
-    return [ null, err ]
-  }
+		// Full backup
+		if (src && src.length > 0) return await fullBackup(name, src, dest)
+	} catch (err) {
+		return [ null, err ]
+	}
 }
 
-export async function differentialBackup(name: string, src: string, dest: string, ref: string): Promise<[ BackupRecord, Error ]> {
-  try {
-    log(`Validating reference backup ID ...`)
+export async function differentialBackup(
+	name: string,
+	src: string,
+	dest: string,
+	ref: string
+): Promise<[BackupRecord, Error]> {
+	try {
+		log(`Validating reference backup ID ...`)
 
-    // Check if refID passed or refName
-    let refId = ref
-    if (!(/\b[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-\b[0-9a-fA-F]{12}\b/.test(ref))) {
-      // Translate ref name to an ID to use
-      log(`Reference backup was not presented as UUID ... attempting to translate to UUID from presumed name ...`)
-      refId = ref
-    }
+		// Check if refID passed or refName
+		let refId = ref
+		if (!/\b[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-\b[0-9a-fA-F]{12}\b/.test(ref)) {
+			// Translate ref name to an ID to use
+			log(`Reference backup was not presented as UUID ... attempting to translate to UUID from presumed name ...`)
+			refId = ref
+		}
 
-    // Perform the backup and return
-    const mgr: BackupManager = BackupManager.getInstance()
-    log(`Clearing temporary backup buffers ...`)
-    mgr.clearBuffers()
+		// Perform the backup and return
+		const mgr: BackupManager = BackupManager.getInstance()
+		log(`Clearing temporary backup buffers ...`)
+		mgr.clearBuffers()
 
-    // Loading indicator (UI)
-    const spinner = ora('Creating differential backup ...').start()
-    const res = await mgr.diffBackup(refId, resolve(cwd(), src), name, resolve(cwd(), dest))
-    spinner.stop()
-    return res
-  } catch (err) {
-    return [ null, err ]
-  }
+		// Loading indicator (UI)
+		const spinner = ora('Creating differential backup ...').start()
+		const res = await mgr.diffBackup(refId, resolve(cwd(), src), name, resolve(cwd(), dest))
+		spinner.stop()
+		return res
+	} catch (err) {
+		return [ null, err ]
+	}
 }
 
-export async function fullBackup(name: string, src: string, dest: string): Promise<[ BackupRecord, Error ]> {
-  const mgr: BackupManager = BackupManager.getInstance()
-  log(`Clearing temporary backup buffers ...`)
-  mgr.clearBuffers()
-  
-  // Loading indicator (UI)
-  const spinner = ora('Creating full backup ...').start()
-  const res = await mgr.fullBackup(resolve(cwd(), src), name, resolve(cwd(), dest))
-  spinner.stop()
-  return res
+export async function fullBackup(name: string, src: string, dest: string): Promise<[BackupRecord, Error]> {
+	const mgr: BackupManager = BackupManager.getInstance()
+	log(`Clearing temporary backup buffers ...`)
+	mgr.clearBuffers()
+
+	// Loading indicator (UI)
+	const spinner = ora('Creating full backup ...').start()
+	const res = await mgr.fullBackup(resolve(cwd(), src), name, resolve(cwd(), dest))
+	spinner.stop()
+	return res
 }

--- a/src/common/commands/backup.ts
+++ b/src/common/commands/backup.ts
@@ -29,7 +29,7 @@ export async function differentialBackup(name: string, src: string, dest: string
 
     // Check if refID passed or refName
     let refId = ref
-    if (!ref.match('\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b')) {
+    if (!(/\b[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-\b[0-9a-fA-F]{12}\b/.test(ref))) {
       // Translate ref name to an ID to use
       log(`Reference backup was not presented as UUID ... attempting to translate to UUID from presumed name ...`)
       refId = ref

--- a/src/common/commands/parsing.ts
+++ b/src/common/commands/parsing.ts
@@ -2,11 +2,17 @@ import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 
 // Handle parse args
-export function parseArgs(): { [x: string]: unknown;
-		_: (string | number)[]; $0: string; } | 
-		Promise<{ [x: string]: unknown; 
-		_: (string | number)[];
-		$0: string; }> {
+export function parseArgs():
+	| {
+			[x: string]: unknown
+			_: (string | number)[]
+			$0: string
+		}
+	| Promise<{
+			[x: string]: unknown
+			_: (string | number)[]
+			$0: string
+		}> {
 	const cmd = yargs(hideBin(process.argv))
 
 	// Set options
@@ -25,39 +31,39 @@ export function parseArgs(): { [x: string]: unknown;
 	// Configure custom backups
 	cmd.command('backup', 'performs a custom backup of a select directory(s)', (yargs) => {
 		return yargs
-		.positional('name', {
-			describe: 'the name for this backup',
-			type: 'string'
-		})
-		.positional('source', {
-			describe: 'the source directory to use for the backup. This is the directory that will be at the root of your backup',
-			type: 'string'
-		})
-		.positional('dest', {
-			describe: 'the destination path which will contain the backup.',
-			type: 'string'
-		})
-		.option('ref', {
-			description: 'a reference id or name for the full backup used in generating a differential backup based on the reference.',
-			type: 'string'
-		})
+			.positional('name', {
+				describe: 'the name for this backup',
+				type: 'string'
+			})
+			.positional('source', {
+				describe:
+					'the source directory to use for the backup. This is the directory that will be at the root of your backup',
+				type: 'string'
+			})
+			.positional('dest', {
+				describe: 'the destination path which will contain the backup.',
+				type: 'string'
+			})
+			.option('ref', {
+				description:
+					'a reference id or name for the full backup used in generating a differential backup based on the reference.',
+				type: 'string'
+			})
 	})
 
 	// Restore from backup
 	cmd.command('restore', 'perform a restore from a target backup', (yargs) => {
-		yargs.positional('ref', {
-			describe: 'the full uuid or name for the backup to restore',
-			type: 'string'
-		})
-		.positional('dest', {
-			describe: 'path to destination restore directory',
-			type: 'string'
-		})
+		yargs
+			.positional('ref', {
+				describe: 'the full uuid or name for the backup to restore',
+				type: 'string'
+			})
+			.positional('dest', {
+				describe: 'path to destination restore directory',
+				type: 'string'
+			})
 	})
 
 	// Set general parse config
-	return cmd.usage('Usage: $0 <command> [options...]')
-		.demandCommand(1)
-		.version()
-		.argv
+	return cmd.usage('Usage: $0 <command> [options...]').demandCommand(1).version().argv
 }

--- a/src/common/commands/restore.ts
+++ b/src/common/commands/restore.ts
@@ -1,33 +1,33 @@
-import ora from "ora";
-import { resolve } from "path/posix";
-import { cwd } from "process";
-import { log } from "../../lib/logger.js";
-import { RestoreManager } from "../../lib/restore.js";
+import ora from 'ora'
+import { resolve } from 'path/posix'
+import { cwd } from 'process'
+import { log } from '../../lib/logger.js'
+import { RestoreManager } from '../../lib/restore.js'
 
-export async function restoreBackup(ref: string, dest: string): Promise<[ string, Error ]> {
-  if (!ref || ref.length === 0 || !dest || dest.length === 0) {
-    return [ null, new Error('Invalid reference ID or destination specified ...') ]
-  }
+export async function restoreBackup(ref: string, dest: string): Promise<[string, Error]> {
+	if (!ref || ref.length === 0 || !dest || dest.length === 0) {
+		return [ null, new Error('Invalid reference ID or destination specified ...') ]
+	}
 
-  log(`Parameter validation completed ... checking ID format`)
+	log(`Parameter validation completed ... checking ID format`)
 
-  // Check if refID passed or refName
-  let refId = ref
-  if (!(/\b[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-\b[0-9a-fA-F]{12}\b/.test(ref))) {
-    // Translate ref name to an ID to use
-    log(`Reference backup was not presented as UUID ... attempting to translate to UUID from presumed name ...`)
-    refId = ref
-    log(`Translation complete. NAME (${ref}) > UUID (${refId})`)
-  }
+	// Check if refID passed or refName
+	let refId = ref
+	if (!/\b[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-\b[0-9a-fA-F]{12}\b/.test(ref)) {
+		// Translate ref name to an ID to use
+		log(`Reference backup was not presented as UUID ... attempting to translate to UUID from presumed name ...`)
+		refId = ref
+		log(`Translation complete. NAME (${ref}) > UUID (${refId})`)
+	}
 
-  // Loading indicator (UI)
-  const spinner = ora(`Restoring backup for ${refId} ...`).start()
-  const mgr: RestoreManager = RestoreManager.getInstance()
-  const err = await mgr.restore(refId, resolve(cwd(), dest))
-  spinner.stop()
+	// Loading indicator (UI)
+	const spinner = ora(`Restoring backup for ${refId} ...`).start()
+	const mgr: RestoreManager = RestoreManager.getInstance()
+	const err = await mgr.restore(refId, resolve(cwd(), dest))
+	spinner.stop()
 
-  if (err) {
-    return [ null, err ]
-  }
-  return [ refId, null ]
+	if (err) {
+		return [ null, err ]
+	}
+	return [ refId, null ]
 }

--- a/src/common/commands/restore.ts
+++ b/src/common/commands/restore.ts
@@ -13,7 +13,7 @@ export async function restoreBackup(ref: string, dest: string): Promise<[ string
 
   // Check if refID passed or refName
   let refId = ref
-  if (!ref.match('\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b')) {
+  if (!(/\b[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-\b[0-9a-fA-F]{12}\b/.test(ref))) {
     // Translate ref name to an ID to use
     log(`Reference backup was not presented as UUID ... attempting to translate to UUID from presumed name ...`)
     refId = ref

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -7,4 +7,4 @@ export const LOG_KEY = 'log'
 
 // Config value constants
 export const LOG_DEBUG = 'DEBUG'
-export const LOG_INFO  = 'INFO'
+export const LOG_INFO = 'INFO'

--- a/src/common/functions.ts
+++ b/src/common/functions.ts
@@ -1,7 +1,7 @@
 import figlet from "figlet";
 import { userInfo } from "os";
 import { PACKAGE_NAME } from "./constants.js";
-import { BackupRecord } from "./types.js";
+import { BackupRecord, Directory } from "./types.js";
 
 // Pure getAppDataPath
 export function getAppDataPath(): string {
@@ -38,4 +38,11 @@ export function ppRecord(record: BackupRecord): void {
 		{ attribute: 'location', value: record.destRoot }
 	]
 	console.table(tableData)
+}
+
+// Used to sort directories by depth (ascending order)
+export function compareByDepth(dirA: Directory, dirB: Directory): number {
+	if (dirA.depth < dirB.depth) return -1
+	if (dirA.depth > dirB.depth) return 1
+	return 0
 }

--- a/src/common/functions.ts
+++ b/src/common/functions.ts
@@ -1,7 +1,7 @@
-import figlet from "figlet";
-import { userInfo } from "os";
-import { PACKAGE_NAME } from "./constants.js";
-import { BackupRecord, Directory } from "./types.js";
+import figlet from 'figlet'
+import { userInfo } from 'os'
+import { PACKAGE_NAME } from './constants.js'
+import { BackupRecord, Directory } from './types.js'
 
 // Pure getAppDataPath
 export function getAppDataPath(): string {
@@ -21,8 +21,7 @@ export function getAppDataPath(): string {
 // App Say
 export function sayHello(): void {
 	console.clear()
-	console.log(`${figlet.textSync(PACKAGE_NAME,
-		{ horizontalLayout: 'full' })}\n\n`)
+	console.log(`${figlet.textSync(PACKAGE_NAME, { horizontalLayout: 'full' })}\n\n`)
 }
 
 // Record display (pretty print)

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -18,7 +18,10 @@ export type FileData = {
 
 export type Directory = {
 	path: string
-	deleted: boolean
+	deleted: boolean,
+	mode?: string,
+	uid?: number,
+	gid?: number
 }
 
 export type BackupRecord = {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -18,11 +18,11 @@ export type FileData = {
 
 export type Directory = {
 	path: string
-	deleted: boolean,
-	depth: number,
-	mode?: string,
-	uid?: number,
-	gid?: number,
+	deleted: boolean
+	depth: number
+	mode?: string
+	uid?: number
+	gid?: number
 }
 
 export type BackupRecord = {
@@ -44,7 +44,7 @@ export type RecordType = {
 }
 
 // App Config
-export type SomeConfigData = string|Record<string, unknown>
+export type SomeConfigData = string | Record<string, unknown>
 
 export type AppConfigObject = {
 	db: SomeConfigData
@@ -52,6 +52,6 @@ export type AppConfigObject = {
 }
 
 export type ConfigStoreOptions = {
-	configName: string,
+	configName: string
 	defaults?: AppConfigObject
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -19,9 +19,10 @@ export type FileData = {
 export type Directory = {
 	path: string
 	deleted: boolean,
+	depth: number,
 	mode?: string,
 	uid?: number,
-	gid?: number
+	gid?: number,
 }
 
 export type BackupRecord = {

--- a/src/config/backuply.ts
+++ b/src/config/backuply.ts
@@ -1,5 +1,5 @@
-import { getAppDataPath } from "../common/functions.js";
-import { AppConfigObject } from "../common/types.js";
+import { getAppDataPath } from '../common/functions.js'
+import { AppConfigObject } from '../common/types.js'
 
 export const defaults: AppConfigObject = {
 	db: {

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -370,19 +370,14 @@ export class BackupManager {
 			if (createErr) {
 				throw new IOException(`Could not create the backup directory. Aborting... (${createErr.message})`)
 			}
-			// Note: we can use copy standalone for FULL backups since they require little additional computation
-			// await copy(source, `${destination}/${generatedBackupName}`, {
-			// 	overwrite: true,
-			// 	preserveTimestamps: true,
-			// 	errorOnExist: false
-			// })
+			
 
+			// Where empty directories exist and are not captured (create them)
 			await this._handleCreatedEmptyDirectories(dirData, source, join(destination, generatedBackupName))
-
 			await this._copySelectFilesAsync(
 				source,
 				fileData,
-				`${destination}/${generatedBackupName}`
+				join(destination, generatedBackupName)
 			)
 
 			// Create backup record to store into the database

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -306,15 +306,16 @@ export class BackupManager {
 			if (createErr) {
 				throw new IOException(`Could not create the backup directory. Aborting... (${createErr.message})`)
 			}
+
+			// Special case: in the event an empty directory is added (create it in diff backup)
+			await this._handleCreatedEmptyDirectories(dChanged, join(destination, generatedBackupName))
+
 			await this._copySelectFilesAsync(
 				source,
 				fChanged,
 				join(destination, generatedBackupName),
 				dChanged.filter((d) => d.deleted)
 			)
-
-			// Special case: in the event an empty directory is added (create it in diff backup)
-			await this._handleCreatedEmptyDirectories(dChanged, join(destination, generatedBackupName))
 
 			// Create && update backup record for this diff backup
 			const [ backupSize, sizeError ] = await this._getTotalByteLengthOfBackup(fChanged)
@@ -377,7 +378,7 @@ export class BackupManager {
 			// 	errorOnExist: false
 			// })
 
-			await this._handleCreatedEmptyDirectories(dirData, `${destination}/${generatedBackupName}`)
+			await this._handleCreatedEmptyDirectories(dirData, join(destination, generatedBackupName))
 
 			await this._copySelectFilesAsync(
 				source,

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -254,12 +254,11 @@ export class BackupManager {
 		return
 	}
 
-	private async _handleCreatedEmptyDirectories(directories: Directory[], destRoot: string): Promise<Error> {
+	private async _handleCreatedEmptyDirectories(directories: Directory[], sourceRoot: string, destRoot: string): Promise<Error> {
 		try {
-			// Instead of copying, we just create the directories
-			directories.map((d) => {
-				if (!d.deleted) this._createDirectory(destRoot, d.path)
-			})
+			for (const d of directories) {
+				if (!d.deleted) this._createDirectory(destRoot, d.path.split(sourceRoot)[1])
+			}
 		} catch (err) {
 			return err
 		}
@@ -308,7 +307,7 @@ export class BackupManager {
 			}
 
 			// Special case: in the event an empty directory is added (create it in diff backup)
-			await this._handleCreatedEmptyDirectories(dChanged, join(destination, generatedBackupName))
+			await this._handleCreatedEmptyDirectories(dChanged, source, join(destination, generatedBackupName))
 
 			await this._copySelectFilesAsync(
 				source,
@@ -378,7 +377,7 @@ export class BackupManager {
 			// 	errorOnExist: false
 			// })
 
-			await this._handleCreatedEmptyDirectories(dirData, join(destination, generatedBackupName))
+			await this._handleCreatedEmptyDirectories(dirData, source, join(destination, generatedBackupName))
 
 			await this._copySelectFilesAsync(
 				source,

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -1,4 +1,4 @@
-import { mkdir, stat, readdir } from 'fs/promises'
+import { mkdir, lstat, readdir } from 'fs/promises'
 import { join } from 'path'
 import { copy, pathExists } from 'fs-extra'
 import { BackupRecord, BackupType, Directory, FileData, RecordTable } from '../common/types.js'
@@ -132,7 +132,7 @@ export class BackupManager {
 			const dirContents = await readdir(root)
 			for (const item of dirContents) {
 				const absPath = join(root, item)
-				const pStat = await stat(absPath)
+				const pStat = await lstat(absPath)
 
 				if (pStat.isDirectory()) {
 					// store the directory path in a temporary buffer and recurse

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -377,6 +377,8 @@ export class BackupManager {
 			// 	errorOnExist: false
 			// })
 
+			await this._handleCreatedEmptyDirectories(dirData, `${destination}/${generatedBackupName}`)
+
 			await this._copySelectFilesAsync(
 				source,
 				fileData,

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -141,7 +141,7 @@ export class BackupManager {
 				} else {
 					// If not directory or symlink store in temporary files buffer
 					// TODO: eventually come up with proper fix for symlinks
-					if (pStat.isFile() && !pStat.isSymbolicLink()) this.filesBuffer.push(absPath)
+					this.filesBuffer.push(absPath)
 				}
 			}
 		} catch (err) {

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -1,5 +1,5 @@
 import { mkdir, lstat, readdir, chown } from 'fs/promises'
-import { join, resolve, sep } from 'path/posix'
+import { join, sep } from 'path/posix'
 import { copy, pathExists } from 'fs-extra'
 import { BackupRecord, BackupType, Directory, FileData, RecordTable } from '../common/types.js'
 import { v4 as uuid } from 'uuid'

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -140,8 +140,7 @@ export class BackupManager {
 					await this._generateBackupTreeFromRoot(absPath)
 				} else {
 					// If not directory or symlink store in temporary files buffer
-					// TODO: eventually come up with proper fix for symlinks
-					if (pStat.isFile()) this.filesBuffer.push(absPath)
+					if (pStat.isFile() && !pStat.isSocket()) this.filesBuffer.push(absPath)
 				}
 			}
 		} catch (err) {

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -134,7 +134,7 @@ export class BackupManager {
 				const absPath = join(root, item)
 				const pStat = await stat(absPath)
 				const isDir = pStat.isDirectory()
-				const isLink = pStat.isSymbolicLink()
+				const isFile = pStat.isFile()
 
 				if (isDir) {
 					// store the directory path in a temporary buffer
@@ -143,7 +143,7 @@ export class BackupManager {
 				} else {
 					// If not directory or symlink store in temporary files buffer
 					// TODO: eventually come up with proper fix for symlinks
-					if (!isLink) this.filesBuffer.push(absPath)
+					if (isFile) this.filesBuffer.push(absPath)
 				}
 			}
 		} catch (err) {

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -141,7 +141,7 @@ export class BackupManager {
 				} else {
 					// If not directory or symlink store in temporary files buffer
 					// TODO: eventually come up with proper fix for symlinks
-					this.filesBuffer.push(absPath)
+					if (pStat.isFile()) this.filesBuffer.push(absPath)
 				}
 			}
 		} catch (err) {

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -356,6 +356,7 @@ export class BackupManager {
 				throw new IOException(`Could not create the backup directory. Aborting... (${createErr.message})`)
 			}
 
+			// Create backup structure based on directories with changes and copy files
 			await this._createDirectoryStructure(dChanged, source, join(destination, generatedBackupName))
 			await this._copySelectFilesAsync(
 				source,
@@ -422,7 +423,7 @@ export class BackupManager {
 				throw new IOException(`Could not create the backup directory. Aborting... (${createErr.message})`)
 			}
 
-			// Where empty directories exist and are not captured (create them)
+			// Create full structure (and persist permisssions/ownership) and copy files
 			await this._createDirectoryStructure(dirData, source, join(destination, generatedBackupName))
 			await this._copySelectFilesAsync(source, fileData, join(destination, generatedBackupName))
 

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -140,7 +140,7 @@ export class BackupManager {
 					await this._generateBackupTreeFromRoot(absPath)
 				} else {
 					// If not directory or symlink store in temporary files buffer
-					if ((pStat.isFile() || pStat.isSymbolicLink()) && !pStat.isSocket()) this.filesBuffer.push(absPath)
+					if (pStat.isFile() && !pStat.isSocket()) this.filesBuffer.push(absPath)
 				}
 			}
 		} catch (err) {

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -133,17 +133,15 @@ export class BackupManager {
 			for (const item of dirContents) {
 				const absPath = join(root, item)
 				const pStat = await stat(absPath)
-				const isDir = pStat.isDirectory()
-				const isFile = pStat.isFile()
 
-				if (isDir) {
-					// store the directory path in a temporary buffer
+				if (pStat.isDirectory()) {
+					// store the directory path in a temporary buffer and recurse
 					this.directoriesBuffer.push(absPath)
 					await this._generateBackupTreeFromRoot(absPath)
 				} else {
 					// If not directory or symlink store in temporary files buffer
 					// TODO: eventually come up with proper fix for symlinks
-					if (isFile) this.filesBuffer.push(absPath)
+					if (pStat.isFile() && !pStat.isSymbolicLink()) this.filesBuffer.push(absPath)
 				}
 			}
 		} catch (err) {

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -140,7 +140,7 @@ export class BackupManager {
 					await this._generateBackupTreeFromRoot(absPath)
 				} else {
 					// If not directory or symlink store in temporary files buffer
-					if (pStat.isFile() && !pStat.isSocket()) this.filesBuffer.push(absPath)
+					if ((pStat.isFile() || pStat.isSymbolicLink()) && !pStat.isSocket()) this.filesBuffer.push(absPath)
 				}
 			}
 		} catch (err) {
@@ -371,11 +371,17 @@ export class BackupManager {
 				throw new IOException(`Could not create the backup directory. Aborting... (${createErr.message})`)
 			}
 			// Note: we can use copy standalone for FULL backups since they require little additional computation
-			await copy(source, `${destination}/${generatedBackupName}`, {
-				overwrite: true,
-				preserveTimestamps: true,
-				errorOnExist: false
-			})
+			// await copy(source, `${destination}/${generatedBackupName}`, {
+			// 	overwrite: true,
+			// 	preserveTimestamps: true,
+			// 	errorOnExist: false
+			// })
+
+			await this._copySelectFilesAsync(
+				source,
+				fileData,
+				`${destination}/${generatedBackupName}`
+			)
 
 			// Create backup record to store into the database
 			const [ backupSize, sizeError ] = this._getTotalByteLengthOfBackup(fileData)

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -132,15 +132,18 @@ export class BackupManager {
 			const dirContents = await readdir(root)
 			for (const item of dirContents) {
 				const absPath = join(root, item)
-				const isDir = (await stat(absPath)).isDirectory()
+				const pStat = await stat(absPath)
+				const isDir = pStat.isDirectory()
+				const isLink = pStat.isSymbolicLink()
 
 				if (isDir) {
 					// store the directory path in a temporary buffer
 					this.directoriesBuffer.push(absPath)
 					await this._generateBackupTreeFromRoot(absPath)
 				} else {
-					// If not directory store in temporary files buffer
-					this.filesBuffer.push(absPath)
+					// If not directory or symlink store in temporary files buffer
+					// TODO: eventually come up with proper fix for symlinks
+					if (!isLink) this.filesBuffer.push(absPath)
 				}
 			}
 		} catch (err) {

--- a/src/lib/configstore.ts
+++ b/src/lib/configstore.ts
@@ -1,63 +1,65 @@
-import { readFileSync, writeFileSync } from "fs";
-import { mkdirpSync } from "fs-extra";
-import path, { join } from "path/posix";
-import { getAppDataPath } from "../common/functions.js";
-import { AppConfigObject, ConfigStoreOptions, SomeConfigData } from "../common/types.js";
-import { defaults } from "../config/backuply.js";
+import { readFileSync, writeFileSync } from 'fs'
+import { mkdirpSync } from 'fs-extra'
+import path, { join } from 'path/posix'
+import { getAppDataPath } from '../common/functions.js'
+import { AppConfigObject, ConfigStoreOptions, SomeConfigData } from '../common/types.js'
+import { defaults } from '../config/backuply.js'
 
 export class ConfigStore {
-  private path: string
-  private data: AppConfigObject
-  
-  constructor(opts: ConfigStoreOptions) {
-    const userDataPath = getAppDataPath()
-    this.path = join(userDataPath, `${opts.configName}.json`)
-    this.data = this.parseDataFile(opts.defaults || {
-      ...defaults
-    })
-  }
+	private path: string
+	private data: AppConfigObject
 
-  get(key: string): [ SomeConfigData, Error ] {
-    try {
-      const data = this.data[key]
-      
-      if (!data) {
-        throw new Error(`Config data not found for key ${key}...`)
-      }
-      return [ data, null ]
-    } catch (err) {
-      return [ null, err ]
-    }
-  }
+	constructor(opts: ConfigStoreOptions) {
+		const userDataPath = getAppDataPath()
+		this.path = join(userDataPath, `${opts.configName}.json`)
+		this.data = this.parseDataFile(
+			opts.defaults || {
+				...defaults
+			}
+		)
+	}
 
-  set(key: string, val: SomeConfigData): Error {
-    try {
-      this.data[key] = val
-      writeFileSync(this.path, JSON.stringify(this.data))
-    } catch (err) {
-      return err
-    }
-  }
+	get(key: string): [SomeConfigData, Error] {
+		try {
+			const data = this.data[key]
 
-  has(key: string): [ boolean, Error ] {
-    try {
-      const data = this.data[key]
-      return [ data === null || data === undefined, null]
-    } catch (err) {
-      return [ null, err ]
-    }
-  }
+			if (!data) {
+				throw new Error(`Config data not found for key ${key}...`)
+			}
+			return [ data, null ]
+		} catch (err) {
+			return [ null, err ]
+		}
+	}
 
-  private parseDataFile(defaults?: AppConfigObject): AppConfigObject {
-    try {
-      return JSON.parse(readFileSync(this.path).toString('utf8'))
-    } catch (err) {
-      // Use defaults
-      mkdirpSync(path.dirname(this.path))
+	set(key: string, val: SomeConfigData): Error {
+		try {
+			this.data[key] = val
+			writeFileSync(this.path, JSON.stringify(this.data))
+		} catch (err) {
+			return err
+		}
+	}
 
-      this.data = defaults
-      writeFileSync(this.path, JSON.stringify(defaults), {flag: 'w'})
-      return defaults
-    }
-  }
+	has(key: string): [boolean, Error] {
+		try {
+			const data = this.data[key]
+			return [ data === null || data === undefined, null ]
+		} catch (err) {
+			return [ null, err ]
+		}
+	}
+
+	private parseDataFile(defaults?: AppConfigObject): AppConfigObject {
+		try {
+			return JSON.parse(readFileSync(this.path).toString('utf8'))
+		} catch (err) {
+			// Use defaults
+			mkdirpSync(path.dirname(this.path))
+
+			this.data = defaults
+			writeFileSync(this.path, JSON.stringify(defaults), { flag: 'w' })
+			return defaults
+		}
+	}
 }

--- a/src/lib/configuration.ts
+++ b/src/lib/configuration.ts
@@ -1,30 +1,30 @@
-import { AppConfigObject, SomeConfigData } from "../common/types.js"
-import { ConfigStore } from "./configstore.js"
+import { AppConfigObject, SomeConfigData } from '../common/types.js'
+import { ConfigStore } from './configstore.js'
 
 export class AppConfig {
-  private static instance: AppConfig
-  private store: ConfigStore
+	private static instance: AppConfig
+	private store: ConfigStore
 
-  private constructor(defaults?: AppConfigObject) {
-    this.store = new ConfigStore({configName: 'user-preferences', defaults: defaults})
-  }
+	private constructor(defaults?: AppConfigObject) {
+		this.store = new ConfigStore({ configName: 'user-preferences', defaults: defaults })
+	}
 
-  public static getInstance(defaults?: AppConfigObject): AppConfig {
-    if (!AppConfig.instance) {
-      AppConfig.instance = new AppConfig(defaults)
-    }
-    return AppConfig.instance
-  }
+	public static getInstance(defaults?: AppConfigObject): AppConfig {
+		if (!AppConfig.instance) {
+			AppConfig.instance = new AppConfig(defaults)
+		}
+		return AppConfig.instance
+	}
 
-  getValue(key: string): [ SomeConfigData, Error ] {
-      const [ value, error ] = this.store.get(key)
-      if (error) return [ null, error ]
-      return [ value, null ]
-  }
+	getValue(key: string): [SomeConfigData, Error] {
+		const [ value, error ] = this.store.get(key)
+		if (error) return [ null, error ]
+		return [ value, null ]
+	}
 
-  setValue(key: string, value: SomeConfigData): [ string, Error ] {
-    const err = this.store.set(key, value)
-    if (err) return [ null, err ]
-    return [ JSON.stringify(value), null ]
-  }
+	setValue(key: string, value: SomeConfigData): [string, Error] {
+		const err = this.store.set(key, value)
+		if (err) return [ null, err ]
+		return [ JSON.stringify(value), null ]
+	}
 }

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1,114 +1,114 @@
 import { JSONFile, Low } from 'lowdb'
 import { BackupRecord, RecordTable, RecordType } from '../common/types.js'
-import { RecordNotFoundException } from '../common/exceptions.js' 
+import { RecordNotFoundException } from '../common/exceptions.js'
 import { AppConfig } from './configuration.js'
 import { DB_KEY } from '../common/constants.js'
 import { resolve } from 'path/posix'
 import { cwd } from 'process'
 
 export class DatabaseManager {
-  private static instance: DatabaseManager
-  private dbClient: Low<RecordType>
+	private static instance: DatabaseManager
+	private dbClient: Low<RecordType>
 
 	private constructor(dbPath: string) {
 		const adapter = new JSONFile<RecordType>(dbPath)
-    this.dbClient = new Low<RecordType>(adapter)
+		this.dbClient = new Low<RecordType>(adapter)
 	}
 
-  public static getInstance(path?: string): DatabaseManager {
-    if (!DatabaseManager.instance) {
-      const [ value, error ] = AppConfig.getInstance().getValue(DB_KEY)
-      if (error) {
-        throw new Error(`Could not create database instance. Reason: ${error.message}`)
-      }
-      DatabaseManager.instance = new DatabaseManager(path ? path : resolve(cwd(), value['path'].toString()))
-    }
+	public static getInstance(path?: string): DatabaseManager {
+		if (!DatabaseManager.instance) {
+			const [ value, error ] = AppConfig.getInstance().getValue(DB_KEY)
+			if (error) {
+				throw new Error(`Could not create database instance. Reason: ${error.message}`)
+			}
+			DatabaseManager.instance = new DatabaseManager(path ? path : resolve(cwd(), value['path'].toString()))
+		}
 
-    return DatabaseManager.instance
-  }
+		return DatabaseManager.instance
+	}
 
-  async init(): Promise<void> {
-    try {
-      // Read data as exists (set db.data content)
-      await this.dbClient.read()
+	async init(): Promise<void> {
+		try {
+			// Read data as exists (set db.data content)
+			await this.dbClient.read()
 
-      // Init data if datafile doesn't exist
-      this.dbClient.data ||= { backups: [], archive: [] }
-      await this.dbClient.write()
-    } catch (err) {
-      throw new Error(`Error occurred when initializing localdb. ${err}`)
-    }
-  }
+			// Init data if datafile doesn't exist
+			this.dbClient.data ||= { backups: [], archive: [] }
+			await this.dbClient.write()
+		} catch (err) {
+			throw new Error(`Error occurred when initializing localdb. ${err}`)
+		}
+	}
 
-  findRecordById(id: string, table: RecordTable = RecordTable.BACKUPS): [BackupRecord, Error] {
-    try {
-      let backup: BackupRecord
-      switch (table) {
-        case RecordTable.BACKUPS:
-          backup = this.dbClient.data.backups.find((backup) => backup.id === id)
-          break;
-        case RecordTable.ARCHIVE:
-          backup = this.dbClient.data.archive.find((backup) => backup.id === id)
-      }
+	findRecordById(id: string, table: RecordTable = RecordTable.BACKUPS): [BackupRecord, Error] {
+		try {
+			let backup: BackupRecord
+			switch (table) {
+				case RecordTable.BACKUPS:
+					backup = this.dbClient.data.backups.find((backup) => backup.id === id)
+					break
+				case RecordTable.ARCHIVE:
+					backup = this.dbClient.data.archive.find((backup) => backup.id === id)
+			}
 
-      if (!backup) {
-        throw new RecordNotFoundException(id, `Record could not be found with Id, ${id}`)
-      }
+			if (!backup) {
+				throw new RecordNotFoundException(id, `Record could not be found with Id, ${id}`)
+			}
 
-      return [backup, null]
-    } catch (err) {
-      return [null, err]
-    }
-  }
+			return [ backup, null ]
+		} catch (err) {
+			return [ null, err ]
+		}
+	}
 
-  async insert(table: RecordTable, data: BackupRecord): Promise<void> {
-    try {
-      switch (table) {
-        case RecordTable.BACKUPS:
-          this.dbClient.data.backups.push({...data})
-          break;
-        case RecordTable.ARCHIVE:
-          this.dbClient.data.archive.push({...data})
-          break;
-        default:
-          break;
-      }
+	async insert(table: RecordTable, data: BackupRecord): Promise<void> {
+		try {
+			switch (table) {
+				case RecordTable.BACKUPS:
+					this.dbClient.data.backups.push({ ...data })
+					break
+				case RecordTable.ARCHIVE:
+					this.dbClient.data.archive.push({ ...data })
+					break
+				default:
+					break
+			}
 
-      await this.dbClient.write()
-    } catch (err) {
-      throw new Error(`Error occurred when inserting new backup record. ${err}`)
-    }
-  }
+			await this.dbClient.write()
+		} catch (err) {
+			throw new Error(`Error occurred when inserting new backup record. ${err}`)
+		}
+	}
 
-  async archive(id: string): Promise<[BackupRecord, Error]> { 
-    try {
-      const [backup, error] = await this.findRecordById(id)
-      if (error) {
-        return [null, error]
-      }
+	async archive(id: string): Promise<[BackupRecord, Error]> {
+		try {
+			const [ backup, error ] = await this.findRecordById(id)
+			if (error) {
+				return [ null, error ]
+			}
 
-      // Perform the migration from backup -> archive
-      await this.insert(RecordTable.ARCHIVE, {...backup})
-      return [await this.delete(backup.id, RecordTable.BACKUPS)[0], null]
-    } catch (err) {
-      return [null, err]
-    }
-  }
+			// Perform the migration from backup -> archive
+			await this.insert(RecordTable.ARCHIVE, { ...backup })
+			return [ await this.delete(backup.id, RecordTable.BACKUPS)[0], null ]
+		} catch (err) {
+			return [ null, err ]
+		}
+	}
 
-  async delete(id: string, table: RecordTable = RecordTable.BACKUPS): Promise<[BackupRecord, Error]> {
-    try {
-      const [backupItem, error] = this.findRecordById(id, table)
-      if (error) {
-        return [null, error]
-      }
+	async delete(id: string, table: RecordTable = RecordTable.BACKUPS): Promise<[BackupRecord, Error]> {
+		try {
+			const [ backupItem, error ] = this.findRecordById(id, table)
+			if (error) {
+				return [ null, error ]
+			}
 
-      // Delete the record
-      this.dbClient.data.backups = this.dbClient.data.backups.filter((backup) => backup.id !== id)
-      await this.dbClient.write()
+			// Delete the record
+			this.dbClient.data.backups = this.dbClient.data.backups.filter((backup) => backup.id !== id)
+			await this.dbClient.write()
 
-      return [backupItem, null]
-    } catch (err) {
-      return [null, err]
-    }
-  }
+			return [ backupItem, null ]
+		} catch (err) {
+			return [ null, err ]
+		}
+	}
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,5 +1,5 @@
-import { LOG_DEBUG, LOG_KEY, PACKAGE_NAME } from "../common/constants.js"
-import { AppConfig } from "./configuration.js"
+import { LOG_DEBUG, LOG_KEY, PACKAGE_NAME } from '../common/constants.js'
+import { AppConfig } from './configuration.js'
 
 function _getCallingFn(): Record<string, string> {
 	try {
@@ -8,7 +8,7 @@ function _getCallingFn(): Record<string, string> {
 		const allMatches = e.stack.match(/(\w+)@|at (\w+) \((.*)/g)
 
 		// match parent function name and path
-		const allMatchesValid = allMatches[allMatches.length-1] || allMatches[1]
+		const allMatchesValid = allMatches[allMatches.length - 1] || allMatches[1]
 		const parentMatches = allMatchesValid.match(/(\w+)@|at (\w+) \((.*)/)
 
 		// return caller function name and file
@@ -25,7 +25,7 @@ function _getCallingFn(): Record<string, string> {
 }
 
 export function log(message: string): void {
-	const [logConf, err] = AppConfig.getInstance().getValue(LOG_KEY)
+	const [ logConf, err ] = AppConfig.getInstance().getValue(LOG_KEY)
 
 	if (err) {
 		console.warn('Failed to determine log level automatically ... defaulting to INFO')
@@ -38,5 +38,9 @@ export function log(message: string): void {
 		callingFunction = _getCallingFn()
 	}
 
-	console.log(`[${new Date().toISOString()}] [${logConf['level']}]${debug ? ` [${callingFunction.functionName}:${callingFunction.fileName}]` : ''} >>> ${message}`)
+	console.log(
+		`[${new Date().toISOString()}] [${logConf['level']}]${debug
+			? ` [${callingFunction.functionName}:${callingFunction.fileName}]`
+			: ''} >>> ${message}`
+	)
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -2,18 +2,25 @@ import { LOG_DEBUG, LOG_KEY, PACKAGE_NAME } from "../common/constants.js"
 import { AppConfig } from "./configuration.js"
 
 function _getCallingFn(): Record<string, string> {
-  const e = new Error()
-	// matches this function, the caller and the parent
-	const allMatches = e.stack.match(/(\w+)@|at (\w+) \((.*)/g)
+	try {
+		const e = new Error()
+		// matches this function, the caller and the parent
+		const allMatches = e.stack.match(/(\w+)@|at (\w+) \((.*)/g)
 
-	// match parent function name and path
-	const allMatchesValid = allMatches[allMatches.length-1] || allMatches[1]
-	const parentMatches = allMatchesValid.match(/(\w+)@|at (\w+) \((.*)/)
+		// match parent function name and path
+		const allMatchesValid = allMatches[allMatches.length-1] || allMatches[1]
+		const parentMatches = allMatchesValid.match(/(\w+)@|at (\w+) \((.*)/)
 
-	// return caller function name and file
-	return {
-		functionName: parentMatches[1] || parentMatches[2],
-		fileName: parentMatches[3].split(`${PACKAGE_NAME}/`)[1].match(/^(.+)\/([^/]+)$/)[0].replace(')', '')
+		// return caller function name and file
+		return {
+			functionName: parentMatches[1] || parentMatches[2],
+			fileName: parentMatches[3].split(`${PACKAGE_NAME}/`)[1].match(/^(.+)\/([^/]+)$/)[0].replace(')', '')
+		}
+	} catch (err) {
+		return {
+			functionName: 'unknown',
+			fileName: 'unknown'
+		}
 	}
 }
 

--- a/src/lib/restore.ts
+++ b/src/lib/restore.ts
@@ -52,7 +52,7 @@ export class RestoreManager {
 				for (const df of diffBackup.fileList) {
 					df.fullPath = await this._updatePathRoot(df.fullPath, diffBackup.sourceRoot, diffBackup.destRoot)
 					const dbRelPath = df.fullPath.split(diffBackup.name).reverse()[0]
-					
+
 					if (fbRelPath === dbRelPath) {
 						// File Deleted
 						if (df.deleted) fileSet.delete(ff)


### PR DESCRIPTION
Was initially opting to ignore symlinks entirely, but if I do not follow the symlink by using `lstat` instead of `stat`, the issue seems to be resolved in a much more effective manner. Being mainly that the symlinks are reserved in the backup and should hold the reference when/if restored. Of course more testing will be required to verify this...

Closes #33 
Closes #44 
Closes #45 